### PR TITLE
Tweak hyperdrive storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "hyperdrive": "^10.21.0",
     "hyperswarm-web": "^2.1.1",
     "mixmap-georender": "^3.0.0",
-    "random-access-memory": "^4.0.0",
+    "random-access-memory": "^3.1.4",
     "viewbox-query-planner": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "bbox-intersect": "^0.1.2",
     "georender-pack": "^4.0.0",
     "get-image-pixels": "^1.0.1",
+    "hyperdrive": "^10.21.0",
+    "hyperswarm-web": "^2.1.1",
     "mixmap-georender": "^3.0.0",
+    "random-access-memory": "^4.0.0",
     "viewbox-query-planner": "^1.0.1"
   },
   "devDependencies": {

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -12,6 +12,7 @@ var DEFAULT_SWARM_OPTS = {
 
 module.exports = function (url, opts) {
   opts = opts || {}
+  var debug = opts.debug || false
   var key = url.replace(/^hyper:[\/]*/,'')
   var drive = new Hyperdrive(RAM, key)
   var isOpen = false
@@ -28,9 +29,15 @@ module.exports = function (url, opts) {
     swarm.join(drive.discoveryKey)
   })
   swarm.on('connection', function (socket, info) {
-    console.log('replicate')
+    console.log('replicate starting with peer', info.host)
     pump(socket, drive.replicate(info.client), socket, function (err) {
-      console.error(err)
+      if (err) console.log('hyperdrive: pump ERROR', err.message)
+    })
+    if (debug) socket.on('data', function (data) {
+      console.log('hyperdrive: data from peer', info.host, data)
+    })
+    socket.on('error', function (err) {
+      console.log('hyperdrive: stream ERROR for peer', info.host, err.message)
     })
     if (!isOpen) open()
   })

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -6,8 +6,8 @@ var hyperswarm = require('hyperswarm-web')
 var RAM = require('random-access-memory')
 var pump = require('pump')
 
-module.exports = function (key) {
-  key = key.replace(/^hyper:[\/]*/,'')
+module.exports = function (url) {
+  var key = url.replace(/^hyper:[\/]*/,'')
   var drive = new Hyperdrive(RAM, key)
   var isOpen = false
   var openQueue = []
@@ -71,6 +71,12 @@ module.exports = function (key) {
         })
       },
     }
+  }
+  storageFn.getRootUrl = function () {
+    return url
+  }
+  storageFn.setRootUrl = function (url) {
+    // no op - changing url on a hyperdrive storage doesn't make sense
   }
   storageFn.destroy = function (name, cb) {
     console.log('destroy',name)

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -29,15 +29,16 @@ module.exports = function (url, opts) {
     swarm.join(drive.discoveryKey)
   })
   swarm.on('connection', function (socket, info) {
-    console.log('replicate starting with peer', info.host)
+    var peer = info.peer
+    console.log('replicate starting with peer', peer.host)
     pump(socket, drive.replicate(info.client), socket, function (err) {
       if (err) console.log('hyperdrive: pump ERROR', err.message)
     })
     if (debug) socket.on('data', function (data) {
-      console.log('hyperdrive: data from peer', info.host, data)
+      console.log('hyperdrive: data from peer', peer.host, data)
     })
     socket.on('error', function (err) {
-      console.log('hyperdrive: stream ERROR for peer', info.host, err.message)
+      console.log('hyperdrive: stream ERROR for peer', peer.host, err.message)
     })
     if (!isOpen) open()
   })

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -23,8 +23,7 @@ module.exports = function (url, opts) {
     }
     openQueue = null
   }
-  var swarmOpts = opts.swarmOpts || DEFAULT_SWARM_OPTS
-  var swarm = hyperswarm(swarmOpts)
+  var swarm = hyperswarm(opts.swarmOpts || DEFAULT_SWARM_OPTS)
   drive.once('ready', function () {
     swarm.join(drive.discoveryKey)
   })
@@ -79,7 +78,7 @@ module.exports = function (url, opts) {
   storageFn.getRootUrl = function () {
     return url
   }
-  storageFn.setRootUrl = function (url) {
+  storageFn.setRootUrl = function () {
     // no op - changing url on a hyperdrive storage doesn't make sense
   }
   storageFn.destroy = function (name, cb) {

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -6,7 +6,12 @@ var hyperswarm = require('hyperswarm-web')
 var RAM = require('random-access-memory')
 var pump = require('pump')
 
-module.exports = function (url) {
+var DEFAULT_SWARM_OPTS = {
+  bootstrap: [ 'wss://swarm.cblgh.org' ]
+}
+
+module.exports = function (url, opts) {
+  opts = opts || {}
   var key = url.replace(/^hyper:[\/]*/,'')
   var drive = new Hyperdrive(RAM, key)
   var isOpen = false
@@ -18,11 +23,10 @@ module.exports = function (url) {
     }
     openQueue = null
   }
+  var swarmOpts = opts.swarmOpts || DEFAULT_SWARM_OPTS
+  var swarm = hyperswarm(swarmOpts)
   drive.once('ready', function () {
     swarm.join(drive.discoveryKey)
-  })
-  var swarm = hyperswarm({
-    bootstrap: [ 'wss://swarm.cblgh.org' ],
   })
   swarm.on('connection', function (socket, info) {
     console.log('replicate')

--- a/storage/hyperdrive.js
+++ b/storage/hyperdrive.js
@@ -61,7 +61,7 @@ module.exports = function (url, opts) {
           return openQueue.push(function () { f(cb) })
         }
         drive.stat(name, { wait: true }, function (err, stat) {
-          console.log('LENGTH',name,err&&err.message,stat)
+          if (debug) console.log('LENGTH',name,err&&err.message,stat)
           if (err) retry(function () { f(cb) })
           else cb(null, stat.size)
         })
@@ -71,12 +71,12 @@ module.exports = function (url, opts) {
           return openQueue.push(function () { f(offset, length, cb) })
         }
         drive.open(name, 'r', function g (err, fd) {
-          console.log('OPEN',name,err&&err.message,fd)
+          if (debug) console.log('OPEN',name,err&&err.message,fd)
           if (err) return retry(function () { f(offset, length, cb) })
           var buf = Buffer.alloc(length)
           drive.read(fd, buf, 0, length, offset, function (err) {
             if (err) return retry(function () { g(null, fd) })
-            console.log('READ',name,err)
+            if (debug) console.log('READ',name,err)
             cb(err, buf)
           })
         })


### PR DESCRIPTION
* pass in `url` and optional `opts` parameter for passing in custom options to `hyperswarm-web`
* add accessors for `url` so we can compare storages and their urls, changing the url for a hyperdrive storage doesn't make sense so it's a no op
* add missing dependencies, like `hyperdrive`, `hyperswarm-web` needed for the hyperdrive storage
* add some extra logging