### PR TITLE
Skip final call to self._recalc() in _loadQuery()

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,6 @@ P.prototype._onviewbox = function (bbox, zoom, cb) {
         self._trace[tr.file] = tr
       }
     })
-    self._scheduleRecalc()
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function P(opts) {
   self._getFont(function (err, font) {
     if (font) {
       self._geotext = geotext({ font })
-      self._recalc()
+      self._scheduleRecalc()
     }
   })
   self._plan = planner()

--- a/index.js
+++ b/index.js
@@ -220,6 +220,7 @@ P.prototype._recalc = function(fromScheduled) {
     self._debug('something is calling _recalc() directly and nothing is scheduled')
   } else if (!fromScheduled && self._recalcTimer) {
     self._debug('something is calling _recalc() directly while already scheduled')
+    return
   }
   self._getStyle(function (stylePixels, styleTexture) {
     self._debug('- BEGIN _recalc() #', ++self._recalcCount)

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ P.prototype._loadQuery = async function loadQuery(bbox, q) {
   var rowCount = 0
   while (row = await q.next()) {
     if (self._queryCanceled[index]) {
-      self._recalc()
+      self._scheduleRecalc()
       return
     }
     ++rowCount
@@ -212,7 +212,6 @@ P.prototype._loadQuery = async function loadQuery(bbox, q) {
   self._debug('_loadQuery number of rows', rowCount)
   self._decodedCache = null
   delete self._queryOpen[index]
-  self._recalc()
 }
 
 P.prototype._recalc = function(fromScheduled) {


### PR DESCRIPTION
If there has been some rows read, they will have made a call
to _scheduleRecalc() already so no need to make an explicit
recalc again

On zoom level 14 and the url http://192.168.10.120:9966/#bbox=7.58525,47.53662,7.62557,47.55646 we remove around 7 seconds from recalc.

Before:

![Screenshot from 2022-08-11 22-10-43](https://user-images.githubusercontent.com/308049/184235955-906e539d-1075-4e0c-b8ba-9e338966f56f.png)

After:

![Screenshot from 2022-08-11 22-19-40](https://user-images.githubusercontent.com/308049/184236025-e60bc2d2-bb9b-47b2-8f15-497758045dc6.png)
